### PR TITLE
Add Workload Generator

### DIFF
--- a/run_inference.sh
+++ b/run_inference.sh
@@ -16,15 +16,15 @@ echo "=== Step 4: Creating results directory ==="
 mkdir -p results
 
 echo "=== Step 5: Running inference (local memory) ==="
-numactl --cpunodebind=0 --membind=0 python inference.py --num_requests=30
+numactl --cpunodebind=0 --membind=0 python inference.py --lambda_rate=3 --simulation_duration=10 --new_conv_prob=0.7
 
 echo "=== Step 6: Running inference (remote memory) ==="
-numactl --cpunodebind=0 python inference.py --kv_method=remote-memory --num_requests=30
+numactl --cpunodebind=0 python inference.py --kv_method=remote-memory --lambda_rate=3 --simulation_duration=10 --new_conv_prob=0.7
 
 echo "=== Step 7: Running inference (disk) ==="
-numactl --cpunodebind=0 python inference.py --kv_method=disk --num_requests=30
+numactl --cpunodebind=0 python inference.py --kv_method=disk --lambda_rate=3 --simulation_duration=10 --new_conv_prob=0.7
 
 echo "=== Step 8: Running inference (tiered memory) ==="
-numactl --cpunodebind=0 python inference.py --tiered_kv_cache=True --num_requests=30
+numactl --cpunodebind=0 python inference.py --tiered_kv_cache=True --lambda_rate=3 --simulation_duration=10 --new_conv_prob=0.7
 
 echo "=== All experiments completed ==="

--- a/workloadGen.py
+++ b/workloadGen.py
@@ -1,0 +1,42 @@
+import numpy as np
+import random
+
+def generate_workload(lambda_rate, simulation_duration, new_conv_prob):
+    """
+    Generate a synthetic workload for a system simulating user requests and conversations.
+    Args:
+        lambda_rate (float): Average number of requests per second.
+        simulation_duration (int): Total duration of the simulation in seconds.
+        new_conv_prob (float): Probability of starting a new conversation.
+    Returns:
+        request_id (int): The ID of the last request processed.
+    """
+
+    inter_arrival_times = np.random.exponential(scale=1/lambda_rate, size=int(lambda_rate * simulation_duration)) # Generate inter-arrival times
+    arrival_times = np.cumsum(inter_arrival_times) # Cumulative sum to get arrival times
+    followup_delay_mean = 1.0 # Seconds
+
+    requests = []
+    active_conversations = {}
+    current_request_id = 0
+
+    for t in arrival_times:
+        if len(active_conversations) == 0 or random.random() < new_conv_prob:
+            request_id = current_request_id
+            current_request_id += 1
+            turn_id = 0
+        else:
+            request_id = random.choice(list(active_conversations.keys()))
+            last_time, last_turn = active_conversations[request_id]
+            t = max(t, last_time + np.random.exponential(followup_delay_mean)) # Ensure the request is after the last turn
+            turn_id = last_turn + 1
+        
+        active_conversations[request_id] = (t, turn_id)
+
+        requests.append({
+            "arrival_time": t,
+            "request_id": request_id,
+            "turn_id": turn_id
+        })
+
+    return requests


### PR DESCRIPTION
This PR adds a workload generator that simulates incoming requests with Poisson-distributed arrival times. It also supports resuming previous conversations by reusing KV cache. Users can configure the following arguments:
- `lambda_rate` and `simulation_duration`: control the request arrival rate and total duration of the simulation.
- `new_conv_prob`: sets the probability of starting a new conversation versus continuing an existing one.